### PR TITLE
Reservoir sampling: Fix off-by-1 in the multi-card example

### DIFF
--- a/reservoir-sampling/src/elements/CardReservoirSample2.ts
+++ b/reservoir-sampling/src/elements/CardReservoirSample2.ts
@@ -238,7 +238,7 @@ export class CardReservoirSample2 extends BaseElement {
       return;
     }
 
-    let i = Math.floor(Math.random() * this.cards.length);
+    let i = Math.floor(Math.random() * (this.cards.length + 1));
     const rand = i;
 
     if (i < 2) {


### PR DESCRIPTION
This fixes an issue similar to that resolved in 47fce396225c89d7b3ecb6a5e75f5d7ccc97580a. The issue was that the third card would always replace one of the first two cards:

https://github.com/user-attachments/assets/72c982f1-af17-4fe5-b6b5-493768cbe9a2

